### PR TITLE
Add HTTP client implementation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,14 +10,22 @@ import (
 )
 
 type config struct {
-	Munch         munch     // Paramters of munch app, excluding external dependencies
-	DocumentStore string    // Name of the prefered DS
-	Mongo         dataStore // Gets picked if DocumentStore is "mongo"
-	DLMRedis      dataStore
+	Munch          munch     // Paramters of munch app, excluding external dependencies
+	DocumentStore  string    // Name of the prefered DS
+	Mongo          dataStore // Gets picked if DocumentStore is "mongo"
+	DLMRedis       dataStore
+	MeteoProviders []meteoProvider
+}
+
+// TODO: Validate URL sting
+type meteoProvider struct {
+	Provider string // Name of the provider
+	APIKey   string
+	URI      string // URL of the provider's API, fully qualified with protocol
 }
 
 type munch struct {
-	Serve munchServer
+	Server munchServer
 }
 
 type munchServer struct {

--- a/http/rest/client.go
+++ b/http/rest/client.go
@@ -1,0 +1,155 @@
+// Package rest provides an HTTP client implementation using the Resty library
+//
+// The idea is to create an abstraction layer over the Resty client to make the codebase agnostic to the underlying HTTP client.
+// This involves defining an interface for the HTTP client and a wrapper for the Resty client that implements this interface.
+// This way, Resty can be easily swapped out for another HTTP client in the future without affecting the calling functions.
+//
+// Example usage:
+//     var client rest.HTTPClient = rest.NewClient().
+//         SetAuthToken("dummy-auth-token").
+//         SetQueryParams(map[string]string{"key": "value"}).
+//         AcceptJSON().
+//         SetOutputDirectory("/path/to/output").
+//         SetPathParams(map[string]string{"userId": "123", "accountId": "456"}).
+//         EnableTrace()
+
+//     resp, err := client.Get("/v1/users/{userId}/{accountId}/details")
+//     if err != nil {
+//     		log.Fatalf("Error: %v", err)
+//     }
+
+//     fmt.Println("Response Status:", resp.Status())
+//     fmt.Println("Response Body:", string(resp.Body()))
+
+//     traceInfo := resp.TraceInfo()
+//     fmt.Printf("Trace Info: %+v\n", traceInfo)
+
+package rest
+
+// TODO: Query params passed through SetQueryParams() and SetQueryString() doesn't seem to work. Passing it via Get() works however.
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// HTTPClient interface defines the methods that an HTTP client should implement.
+type HTTPClient interface {
+	Get(url string) (*Response, error)
+	SetQueryParams(params map[string]string) HTTPClient
+	AcceptJSON() HTTPClient
+	SetQueryString(query string) HTTPClient
+	SetAuthToken(token string) HTTPClient
+	SetOutput(filename string) HTTPClient
+	SetOutputDirectory(dir string) HTTPClient
+	SetPathParams(params map[string]string) HTTPClient
+	EnableTrace() HTTPClient
+	SetDefaults() HTTPClient
+	SetDebug() HTTPClient
+	SetBaseURL(url string) HTTPClient
+}
+
+// Response wraps the Resty response
+type Response struct {
+	restyResponse *resty.Response
+}
+
+// Status returns the HTTP status code
+func (r *Response) Status() string {
+	return r.restyResponse.Status()
+}
+
+// TraceInfo returns the trace information
+func (r *Response) TraceInfo() resty.TraceInfo {
+	return r.restyResponse.Request.TraceInfo()
+}
+
+// Body returns the response body
+func (r *Response) Body() []byte {
+	return r.restyResponse.Body()
+}
+
+// RestyClient struct implements HTTPClient interface
+//
+// RestyClient is a wrapper around Resty client and provides the necessary methods.
+type RestyClient struct {
+	restyClient *resty.Client
+}
+
+// NewClient creates a new RestyClient
+func NewClient() *RestyClient {
+	return &RestyClient{
+		restyClient: resty.New(),
+	}
+}
+
+func (c *RestyClient) Get(url string) (*Response, error) {
+	resp, err := c.restyClient.R().Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make GET request: %w", err)
+	}
+
+	if resp.IsError() {
+		return nil, fmt.Errorf("received error response: %s", resp.Status())
+	}
+
+	return &Response{restyResponse: resp}, nil
+}
+
+func (c *RestyClient) SetQueryParams(params map[string]string) HTTPClient {
+	c.restyClient.R().SetQueryParams(params)
+	return c
+}
+
+func (c *RestyClient) AcceptJSON() HTTPClient {
+	c.restyClient.R().SetHeader("Accept", "application/json")
+	return c
+}
+
+func (c *RestyClient) SetQueryString(query string) HTTPClient {
+	c.restyClient.R().SetQueryString(query)
+	return c
+}
+
+func (c *RestyClient) SetAuthToken(token string) HTTPClient {
+	c.restyClient.R().SetAuthToken(token)
+	return c
+}
+
+func (c *RestyClient) SetOutput(filename string) HTTPClient {
+	c.restyClient.R().SetOutput(filename)
+	return c
+}
+
+func (c *RestyClient) SetOutputDirectory(dir string) HTTPClient {
+	c.restyClient.SetOutputDirectory(dir)
+	return c
+}
+
+func (c *RestyClient) SetPathParams(params map[string]string) HTTPClient {
+	c.restyClient.R().SetPathParams(params)
+	return c
+}
+
+func (c *RestyClient) EnableTrace() HTTPClient {
+	c.restyClient.EnableTrace()
+	return c
+}
+
+func (c *RestyClient) SetDefaults() HTTPClient {
+	c.restyClient.SetRetryCount(3)
+	c.restyClient.SetRetryWaitTime(1 * time.Second)
+	return c
+}
+
+func (c *RestyClient) SetDebug() HTTPClient {
+	c.restyClient.SetDebug(true)
+	return c
+}
+
+func (c *RestyClient) SetBaseURL(url string) HTTPClient {
+	c.restyClient.SetBaseURL(url)
+	return c
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,0 +1,1 @@
+package providers

--- a/server/server.go
+++ b/server/server.go
@@ -6,13 +6,24 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/tinkershack/meteomunch/config"
 	e "github.com/tinkershack/meteomunch/errors"
+	"github.com/tinkershack/meteomunch/http/rest"
 	"github.com/tinkershack/meteomunch/logger"
 )
 
 func Serve(ctx context.Context, args []string) {
 	logger := logger.NewTag("server")
-	logger.Info("Ready, Plank? Serving Meteo Munch.")
+
+	// The following are transient test routes for an early stage development convenience.
+	// These will be cleanedup in the future.
+
+	cfg, err := config.New()
+	if err != nil {
+		logger.Error(e.FAIL, "err", err, "description", "Couldn't parse config")
+		os.Exit(-1)
+	}
+	logger.Info("Config parsed successfully", "config", cfg)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
@@ -20,8 +31,50 @@ func Serve(ctx context.Context, args []string) {
 		fmt.Fprintln(w, "OK")
 		logger.Debug(r.URL.String())
 	})
+	mux.HandleFunc("GET /meteo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+		logger.Info(r.URL.String())
 
-	err := http.ListenAndServe("localhost:8080", mux)
+		var client rest.HTTPClient = rest.NewClient().
+			SetAuthToken("dummy-auth-token").
+			// FIX: SetQueryParams() isn't getting picked up
+			SetQueryParams(map[string]string{
+				"lat":           "47.558",
+				"lon":           "7.587",
+				"asl":           "279",
+				"tz":            "Europe/Zurich",
+				"name":          "Test",
+				"windspeed":     "kmh",
+				"format":        "json",
+				"history_days":  "1",
+				"forecast_days": "0",
+				"apikey":        cfg.MeteoProviders[0].APIKey,
+			}).
+			AcceptJSON().
+			EnableTrace().
+			SetDefaults().
+			SetBaseURL(cfg.MeteoProviders[0].URI).
+			SetDebug()
+			// FIX: SetQueryString isn't getting picked up
+			// SetQueryString("lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey)
+
+		qs := "lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey
+		uri := fmt.Sprintf("packages/air-1h_air-day?%s", qs)
+		resp, err := client.Get(uri)
+		if err != nil {
+			logger.Error(e.FAIL, "err", err, "description", "HTTP request failed!")
+		}
+
+		fmt.Println("Response Status:", resp.Status())
+		fmt.Println("Response Body:", string(resp.Body()))
+
+		traceInfo := resp.TraceInfo()
+		fmt.Printf("Trace Info: %+v\n", traceInfo)
+	})
+
+	logger.Info("Ready, Plank? Serving Meteo Munch on " + cfg.Munch.Server.Hostname + ":" + cfg.Munch.Server.Port)
+	err = http.ListenAndServe(fmt.Sprintf("%s:%s", cfg.Munch.Server.Hostname, cfg.Munch.Server.Port), mux)
 	logger.Error(e.FATAL, "err", err, "description", "Server killed!")
 	os.Exit(-1)
 }


### PR DESCRIPTION
This introduces package rest

The idea is to create an abstraction layer over the Resty client to make the codebase agnostic to the underlying HTTP client. This involves defining an interface for the HTTP client and a wrapper for the Resty client that implements this interface. This way, Resty can be easily swapped out for another HTTP client in the future without affecting the calling functions.