### PR TITLE
Make resty requests stick

### DIFF
--- a/http/rest/client.go
+++ b/http/rest/client.go
@@ -49,6 +49,7 @@ type HTTPClient interface {
 	SetDefaults() HTTPClient
 	SetDebug() HTTPClient
 	SetBaseURL(url string) HTTPClient
+	NewRequest()
 }
 
 // Response wraps the Resty response
@@ -75,7 +76,8 @@ func (r *Response) Body() []byte {
 //
 // RestyClient is a wrapper around Resty client and provides the necessary methods.
 type RestyClient struct {
-	restyClient *resty.Client
+	restyClient  *resty.Client
+	restyRequest *resty.Request
 }
 
 // NewClient creates a new RestyClient
@@ -86,7 +88,7 @@ func NewClient() *RestyClient {
 }
 
 func (c *RestyClient) Get(url string) (*Response, error) {
-	resp, err := c.restyClient.R().Get(url)
+	resp, err := c.restyRequest.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make GET request: %w", err)
 	}
@@ -99,27 +101,27 @@ func (c *RestyClient) Get(url string) (*Response, error) {
 }
 
 func (c *RestyClient) SetQueryParams(params map[string]string) HTTPClient {
-	c.restyClient.R().SetQueryParams(params)
+	c.restyRequest.SetQueryParams(params)
 	return c
 }
 
 func (c *RestyClient) AcceptJSON() HTTPClient {
-	c.restyClient.R().SetHeader("Accept", "application/json")
+	c.restyRequest.SetHeader("Accept", "application/json")
 	return c
 }
 
 func (c *RestyClient) SetQueryString(query string) HTTPClient {
-	c.restyClient.R().SetQueryString(query)
+	c.restyRequest.SetQueryString(query)
 	return c
 }
 
 func (c *RestyClient) SetAuthToken(token string) HTTPClient {
-	c.restyClient.R().SetAuthToken(token)
+	c.restyRequest.SetAuthToken(token)
 	return c
 }
 
 func (c *RestyClient) SetOutput(filename string) HTTPClient {
-	c.restyClient.R().SetOutput(filename)
+	c.restyRequest.SetOutput(filename)
 	return c
 }
 
@@ -129,7 +131,7 @@ func (c *RestyClient) SetOutputDirectory(dir string) HTTPClient {
 }
 
 func (c *RestyClient) SetPathParams(params map[string]string) HTTPClient {
-	c.restyClient.R().SetPathParams(params)
+	c.restyRequest.SetPathParams(params)
 	return c
 }
 
@@ -153,4 +155,8 @@ func (c *RestyClient) SetDebug() HTTPClient {
 func (c *RestyClient) SetBaseURL(url string) HTTPClient {
 	c.restyClient.SetBaseURL(url)
 	return c
+}
+
+func (c *RestyClient) NewRequest() {
+	c.restyRequest = c.restyClient.R()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -25,8 +25,9 @@ func Serve(ctx context.Context, args []string) {
 	}
 	logger.Info("Config parsed successfully", "config", cfg)
 
-	var client rest.HTTPClient = rest.NewClient().
-		SetAuthToken("dummy-auth-token").
+	var client rest.HTTPClient = rest.NewClient()
+	client.NewRequest()
+	client.SetAuthToken("dummy-auth-token").
 		// FIX: SetQueryParams() isn't getting picked up
 		SetQueryParams(map[string]string{
 			"lat":           "47.558",
@@ -40,16 +41,13 @@ func Serve(ctx context.Context, args []string) {
 			"forecast_days": "0",
 			"apikey":        cfg.MeteoProviders[0].APIKey,
 		}).
+		SetQueryString("lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey).
 		AcceptJSON().
 		EnableTrace().
 		SetDefaults().
 		SetBaseURL(cfg.MeteoProviders[0].URI).
 		SetDebug()
-		// FIX: SetQueryString isn't getting picked up
-		// SetQueryString("lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey)
-
-	qs := "lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey
-	uri := fmt.Sprintf("packages/air-1h_air-day?%s", qs)
+	uri := "packages/air-1h_air-day?"
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +59,6 @@ func Serve(ctx context.Context, args []string) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "OK")
 		logger.Info(r.URL.String())
-
 		resp, err := client.Get(uri)
 		if err != nil {
 			logger.Error(e.FAIL, "err", err, "description", "HTTP request failed!")


### PR DESCRIPTION
 - Added restyRequest attribute to the RestyClient type, to refrence to a request
 - Created NewRequest method on RestyClient to create a new request
 - Changed HTTPClient interface to include NewRequest method

Resolves: #1