### PR TITLE
Implement interfaces for providers package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,36 +4,59 @@
 package config
 
 import (
+	"log/slog" // avoiding logger package to prevent cyclic imports
+
 	"github.com/spf13/viper"
 	e "github.com/tinkershack/meteomunch/errors"
-	"github.com/tinkershack/meteomunch/logger"
 )
 
 type config struct {
-	Munch          munch     // Paramters of munch app, excluding external dependencies
-	DocumentStore  string    // Name of the prefered DS
-	Mongo          dataStore // Gets picked if DocumentStore is "mongo"
-	DLMRedis       dataStore
-	MeteoProviders []meteoProvider
+	Munch          Munch     // Parameters of munch app, excluding external dependencies
+	DocumentStore  string    // Name of the preferred DS
+	Mongo          DataStore // Gets picked if DocumentStore is "mongo"
+	DLMRedis       DataStore
+	MeteoProviders []MeteoProvider
+}
+
+func (c *config) GetMunch() Munch {
+	return c.Munch
+}
+
+func (c *config) GetDocumentStore() string {
+	return c.DocumentStore
+}
+
+func (c *config) GetMongo() DataStore {
+	return c.Mongo
+}
+
+func (c *config) GetDLMRedis() DataStore {
+	return c.DLMRedis
+}
+
+func (c *config) GetMeteoProviders() []MeteoProvider {
+	return c.MeteoProviders
 }
 
 // TODO: Validate URL sting
-type meteoProvider struct {
-	Provider string // Name of the provider
-	APIKey   string
-	URI      string // URL of the provider's API, fully qualified with protocol
+type MeteoProvider struct {
+	Name    string
+	APIKey  string
+	APIPath string // Path to the provider's API, excluding the base URI
+	BaseURI string // URI of the provider's API, fully qualified with protocol
 }
 
-type munch struct {
-	Server munchServer
+type Munch struct {
+	Server   MunchServer
+	LogLevel string // Log level for the application
 }
 
-type munchServer struct {
+type MunchServer struct {
 	Hostname string
 	Port     string
 }
 
-type dataStore struct {
+type DataStore struct {
 	Name     string
 	URI      string
 	DBName   string
@@ -46,12 +69,13 @@ var legal = &struct {
 	documentStore: []string{"mongo"},
 }
 
+// TODO: This can be more perfomant by loading it just once and pass a copy for each call
 func New() (*config, error) {
-	log := logger.NewTag("config")
+	// log := logger.NewTag("config")
 	conf := new(config)
 
 	if err := viper.Unmarshal(conf); err != nil {
-		log.Error(e.FAIL, "err", err, "description", "Couldn't parse config")
+		slog.Error(e.FAIL, "err", err, "description", "Couldn't parse config")
 		return nil, err
 	}
 

--- a/http/rest/client.go
+++ b/http/rest/client.go
@@ -49,7 +49,7 @@ type HTTPClient interface {
 	SetDefaults() HTTPClient
 	SetDebug() HTTPClient
 	SetBaseURL(url string) HTTPClient
-	NewRequest()
+	NewRequest() HTTPClient
 }
 
 // Response wraps the Resty response
@@ -143,7 +143,8 @@ func (c *RestyClient) EnableTrace() HTTPClient {
 func (c *RestyClient) SetDefaults() HTTPClient {
 	c.restyClient.SetRetryCount(3)
 	c.restyClient.SetRetryWaitTime(1 * time.Second)
-	c.restyClient.SetTimeout(1 * time.Second)
+	c.restyClient.SetTimeout(1500 * time.Millisecond)
+	c.restyClient.SetHeader("Content-Type", "application/json")
 	return c
 }
 
@@ -157,6 +158,7 @@ func (c *RestyClient) SetBaseURL(url string) HTTPClient {
 	return c
 }
 
-func (c *RestyClient) NewRequest() {
+func (c *RestyClient) NewRequest() HTTPClient {
 	c.restyRequest = c.restyClient.R()
+	return c
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,6 +3,9 @@ package logger
 import (
 	"log/slog"
 	"os"
+
+	"github.com/tinkershack/meteomunch/config"
+	e "github.com/tinkershack/meteomunch/errors"
 )
 
 type Logger *slog.Logger
@@ -15,7 +18,30 @@ func NewTag(tag string) *slog.Logger {
 
 // New returns a new generic instance of a logger that implements Logger interface
 func New() *slog.Logger {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg, err := config.New()
+	if err != nil {
+		slog.Error(e.FAIL, "err", err, "description", "Couldn't parse config")
+	}
+
+	var level slog.Level
+	switch cfg.Munch.LogLevel {
+	case "debug":
+		level = slog.LevelDebug
+	case "info":
+		level = slog.LevelInfo
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, opts))
 	// slog.SetDefault(logger)
 	return logger
 }

--- a/plumber/plumber.go
+++ b/plumber/plumber.go
@@ -8,6 +8,15 @@ type Coordinates struct {
 	Longitude float64 // in degrees
 }
 
+// NewCoordinates creates a new Coordinates struct with the given latitude and longitude.
+// If no parameters are provided, it returns an empty Coordinates struct.
+func NewCoordinates(latitude float64, longitude float64) *Coordinates {
+	return &Coordinates{
+		Latitude:  latitude,
+		Longitude: longitude,
+	}
+}
+
 // Models like Copernicus GLO-90 provide elevation with an accuracy of <4 meters. So, it may not be necessary to capture accuracy separately.
 type Elevation uint // in meters
 
@@ -33,7 +42,7 @@ type BaseData struct {
 	UTCOffsetSeconds     int         `json:"utc_offset_seconds"`
 	Timezone             string      `json:"timezone"`
 	TimezoneAbbreviation string      `json:"timezone_abbreviation"`
-	Elevation            int         `json:"elevation"`
+	Elevation            float64     `json:"elevation"`
 	Current              CurrentData `json:"current"`
 	Hourly               HourlyData  `json:"hourly"`
 	Daily                DailyData   `json:"daily"`
@@ -113,7 +122,7 @@ type HourlyData struct {
 	CloudCoverLow                    []int     `json:"cloud_cover_low"`
 	CloudCoverMid                    []int     `json:"cloud_cover_mid"`
 	CloudCoverHigh                   []int     `json:"cloud_cover_high"`
-	Visibility                       []int     `json:"visibility"`
+	Visibility                       []float64 `json:"visibility"`
 	Evapotranspiration               []float64 `json:"evapotranspiration"`
 	ET0FAOEvapotranspiration         []float64 `json:"et0_fao_evapotranspiration"`
 	VapourPressureDeficit            []float64 `json:"vapour_pressure_deficit"`

--- a/providers/meteoblue.go
+++ b/providers/meteoblue.go
@@ -1,0 +1,74 @@
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tinkershack/meteomunch/config"
+	"github.com/tinkershack/meteomunch/http/rest"
+	"github.com/tinkershack/meteomunch/plumber"
+)
+
+const meteoBlueProviderName = "meteoblue"
+
+type MeteoBlueProvider struct {
+	client rest.HTTPClient
+	config config.MeteoProvider
+}
+
+func NewMeteoBlueProvider() (*MeteoBlueProvider, error) {
+	cfg, err := config.New()
+	if err != nil {
+		return nil, err
+	}
+
+	var meteoConfig config.MeteoProvider
+	found := false
+
+	for _, provider := range cfg.MeteoProviders {
+		if provider.Name == meteoBlueProviderName {
+			meteoConfig = provider
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, errors.New("meteoblue provider configuration not found")
+	}
+
+	return &MeteoBlueProvider{
+		client: rest.NewClient(),
+		config: meteoConfig,
+	}, nil
+}
+
+func (p *MeteoBlueProvider) FetchData(qp map[string]string) (*plumber.BaseData, error) {
+	resp, err := p.client.SetQueryParams(map[string]string{
+		"lat": "11.25",
+		"lon": "77",
+	}).Get("https://my.meteoblue.com/v1/forecast")
+	if err != nil {
+		return nil, err
+	}
+
+	var data struct {
+		Latitude  float64 `json:"lat"`
+		Longitude float64 `json:"lon"`
+		// Add other fields as per the API response
+	}
+
+	if err := json.Unmarshal(resp.Body(), &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Map the JSON response to plumber.BaseData
+	baseData := &plumber.BaseData{
+		Latitude:  data.Latitude,
+		Longitude: data.Longitude,
+		// Map other fields
+	}
+
+	return baseData, nil
+}

--- a/providers/open_meteo.go
+++ b/providers/open_meteo.go
@@ -1,0 +1,105 @@
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tinkershack/meteomunch/config"
+	"github.com/tinkershack/meteomunch/http/rest"
+	"github.com/tinkershack/meteomunch/logger"
+	"github.com/tinkershack/meteomunch/plumber"
+)
+
+const openMeteoProviderName = "open-meteo"
+
+type OpenMeteoProvider struct {
+	client rest.HTTPClient
+	config config.MeteoProvider
+}
+
+// NewOpenMeteoProvider returns a new instance of OpenMeteoProvider
+func NewOpenMeteoProvider() (*OpenMeteoProvider, error) {
+	cfg, err := config.New()
+	if err != nil {
+		return nil, err
+	}
+
+	var meteoConfig config.MeteoProvider
+	found := false
+
+	for _, provider := range cfg.MeteoProviders {
+		if provider.Name == openMeteoProviderName {
+			meteoConfig = provider
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, errors.New("open-meteo provider configuration not found")
+	}
+
+	client := rest.NewClient().SetDefaults().SetBaseURL(meteoConfig.BaseURI)
+	if cfg.Munch.LogLevel == "debug" {
+		client.SetDebug()
+		client.EnableTrace()
+	}
+	client.NewRequest()
+
+	return &OpenMeteoProvider{
+		client: client,
+		config: meteoConfig,
+	}, nil
+}
+
+// FetchData fetches API data from open-meteo provider for the given query parameters map
+func (p *OpenMeteoProvider) FetchData(qp map[string]string) (*plumber.BaseData, error) {
+	resp, err := p.client.SetQueryParams(qp).Get(p.config.APIPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := config.New()
+	if err != nil {
+		return nil, err
+	}
+
+	logger := logger.NewTag("providers:open-meteo")
+
+	if cfg.Munch.LogLevel == "debug" {
+		// Refraining from logger.Debug() as it doesn't pretty print the resty response stats and body
+		// And, this is just for debugging purposes so it's okay to use fmt.Println as it's not logged in production
+		logger.Debug("Response", "status:", resp.Status())
+		logger.Debug("Response", "body:", string(resp.Body()))
+
+		traceInfo := resp.TraceInfo()
+		logger.Debug("Response", "trace", fmt.Sprintf("%+v", traceInfo))
+	}
+
+	data := new(plumber.BaseData) // Fields of the struct will be zero-initialized
+
+	if err := json.Unmarshal(resp.Body(), data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return data, nil
+}
+
+// OpenMeteoQueryParams forms the query parameters for OpenMeteo API based on given coordinates
+func OpenMeteoQueryParams(coords *plumber.Coordinates) map[string]string {
+	qp := map[string]string{
+		"latitude":       fmt.Sprintf("%f", coords.Latitude),
+		"longitude":      fmt.Sprintf("%f", coords.Longitude),
+		"current":        "temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,rain,showers,snowfall,weather_code,cloud_cover,pressure_msl,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m",
+		"hourly":         "temperature_2m,relative_humidity_2m,dew_point_2m,apparent_temperature,precipitation_probability,precipitation,weather_code,pressure_msl,surface_pressure,cloud_cover,cloud_cover_low,cloud_cover_mid,cloud_cover_high,visibility,evapotranspiration,et0_fao_evapotranspiration,vapour_pressure_deficit,wind_speed_10m,wind_speed_80m,wind_speed_120m,wind_speed_180m,wind_direction_10m,wind_direction_80m,wind_direction_120m,wind_direction_180m,wind_gusts_10m,temperature_80m,temperature_120m,temperature_180m,uv_index,uv_index_clear_sky,is_day,sunshine_duration,total_column_integrated_water_vapour,cape,lifted_index,convective_inhibition,freezing_level_height,boundary_layer_height,temperature_1000hPa,temperature_975hPa,temperature_950hPa,temperature_925hPa,temperature_900hPa,temperature_850hPa,temperature_800hPa,temperature_700hPa,temperature_600hPa,temperature_500hPa,temperature_400hPa,relative_humidity_1000hPa,relative_humidity_975hPa,relative_humidity_950hPa,relative_humidity_925hPa,relative_humidity_900hPa,relative_humidity_850hPa,relative_humidity_800hPa,relative_humidity_700hPa,relative_humidity_600hPa,relative_humidity_500hPa,relative_humidity_400hPa,cloud_cover_1000hPa,cloud_cover_975hPa,cloud_cover_950hPa,cloud_cover_925hPa,cloud_cover_900hPa,cloud_cover_850hPa,cloud_cover_800hPa,cloud_cover_700hPa,cloud_cover_600hPa,cloud_cover_500hPa,cloud_cover_400hPa,wind_speed_1000hPa,wind_speed_975hPa,wind_speed_950hPa,wind_speed_925hPa,wind_speed_900hPa,wind_speed_850hPa,wind_speed_800hPa,wind_speed_700hPa,wind_speed_600hPa,wind_speed_500hPa,wind_speed_400hPa,wind_direction_1000hPa,wind_direction_975hPa,wind_direction_950hPa,wind_direction_925hPa,wind_direction_900hPa,wind_direction_850hPa,wind_direction_800hPa,wind_direction_700hPa,wind_direction_600hPa,wind_direction_500hPa,wind_direction_400hPa,geopotential_height_1000hPa,geopotential_height_975hPa,geopotential_height_950hPa,geopotential_height_925hPa,geopotential_height_900hPa,geopotential_height_850hPa,geopotential_height_800hPa,geopotential_height_700hPa,geopotential_height_600hPa,geopotential_height_500hPa,geopotential_height_400hPa",
+		"daily":          "weather_code,temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,sunrise,sunset,daylight_duration,sunshine_duration,uv_index_max,uv_index_clear_sky_max,precipitation_sum,precipitation_hours,precipitation_probability_max,wind_speed_10m_max,wind_gusts_10m_max,wind_direction_10m_dominant,shortwave_radiation_sum,et0_fao_evapotranspiration",
+		"timeformat":     "unixtime",
+		"timezone":       "GMT",
+		"forecast_days":  "1",
+		"forecast_hours": "24",
+		"cell_selection": "nearest",
+		"models":         "best_match",
+	}
+	return qp
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,1 +1,64 @@
+// Package providers offers an interface and a factory method for weather data providers.
+// This package is designed to facilitate the integration of various weather data providers
+// by defining a common interface that each provider must implement. It also includes a
+// factory method to instantiate the appropriate provider based on a given name.
+//
+// The package relies on the following external packages:
+// - github.com/tinkershack/meteomunch/logger: For logging purposes.
+// - github.com/tinkershack/meteomunch/plumber: For handling the base data structure.
+//
+// The main components of this package are:
+// - Provider interface: Defines the methods that each provider must implement.
+// - NewProvider function: A factory method that returns the appropriate provider based on the name.
+//
+// Example usage:
+//
+//	provider, err := providers.NewProvider("open-meteo")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	data, err := provider.FetchData(queryParams)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// The package initializes a logger with the tag "providers" to facilitate logging within the package.
 package providers
+
+import (
+	"fmt"
+
+	"github.com/tinkershack/meteomunch/logger"
+	"github.com/tinkershack/meteomunch/plumber"
+)
+
+var l logger.Logger
+
+func init() {
+	l = logger.NewTag("providers")
+}
+
+// Provider interface defines the methods that each provider must implement
+type Provider interface {
+	FetchData(queryParams map[string]string) (*plumber.BaseData, error)
+}
+
+// NewProvider returns the appropriate provider based on the name
+func NewProvider(name string) (Provider, error) {
+	switch name {
+	case "open-meteo":
+		p, err := NewOpenMeteoProvider()
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	case "meteoblue":
+		p, err := NewMeteoBlueProvider()
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("unknown provider: %s", name)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,8 @@ import (
 	e "github.com/tinkershack/meteomunch/errors"
 	"github.com/tinkershack/meteomunch/http/rest"
 	"github.com/tinkershack/meteomunch/logger"
+	"github.com/tinkershack/meteomunch/plumber"
+	"github.com/tinkershack/meteomunch/providers"
 )
 
 func Serve(ctx context.Context, args []string) {
@@ -25,36 +27,58 @@ func Serve(ctx context.Context, args []string) {
 	}
 	logger.Info("Config parsed successfully", "config", cfg)
 
-	var client rest.HTTPClient = rest.NewClient()
+	// qp := map[string]string{
+	// 	"lat":           "47.558",
+	// 	"lon":           "7.587",
+	// 	"asl":           "279",
+	// 	"tz":            "Europe/Zurich",
+	// 	"name":          "Test",
+	// 	"windspeed":     "kmh",
+	// 	"format":        "json",
+	// 	"history_days":  "1",
+	// 	"forecast_days": "0",
+	// 	"apikey":        cfg.MeteoProviders[0].APIKey,
+	// }
+
+	var client rest.HTTPClient = rest.NewClient().SetDebug()
+	// SetAuthToken("dummy-auth-token").
+	// SetQueryParams(qp).
+	// AcceptJSON().
+	// EnableTrace().
+	// SetDefaults().
+	// SetBaseURL(cfg.MeteoProviders[0].URI).
+	// SetDebug()
+	// FIX: SetQueryString isn't getting picked up
+	// SetQueryString("lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey)
+	client.SetBaseURL(cfg.MeteoProviders[0].BaseURI)
 	client.NewRequest()
-	client.SetAuthToken("dummy-auth-token").
-		// FIX: SetQueryParams() isn't getting picked up
-		SetQueryParams(map[string]string{
-			"lat":           "47.558",
-			"lon":           "7.587",
-			"asl":           "279",
-			"tz":            "Europe/Zurich",
-			"name":          "Test",
-			"windspeed":     "kmh",
-			"format":        "json",
-			"history_days":  "1",
-			"forecast_days": "0",
-			"apikey":        cfg.MeteoProviders[0].APIKey,
-		}).
-		SetQueryString("lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey).
-		AcceptJSON().
-		EnableTrace().
-		SetDefaults().
-		SetBaseURL(cfg.MeteoProviders[0].URI).
-		SetDebug()
-	uri := "packages/air-1h_air-day?"
+
+	qs := "lat=47.558&lon=7.573&asl=279&tz=Europe%2FZurich&name=Test&windspeed=kmh&format=json&history_days=1&forecast_days=0&apikey=" + cfg.MeteoProviders[0].APIKey
+	uri := fmt.Sprintf("packages/air-1h_air-day?%s", qs)
 
 	mux := http.NewServeMux()
+
 	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "OK")
 		logger.Debug(r.URL.String())
 	})
+
+	mux.HandleFunc("GET /open-meteo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+		p, err := providers.NewOpenMeteoProvider()
+		if err != nil {
+			logger.Error(e.FAIL, "err", err, "description", "Couldn't create OpenMeteoProvider")
+		}
+		bd, err := p.FetchData(providers.OpenMeteoQueryParams(plumber.NewCoordinates(11.0056, 76.9661)))
+		if err != nil {
+			logger.Error(e.FAIL, "err", err, "description", "Couldn't fetch data from OpenMeteoProvider")
+		}
+		// fmt.Printf("Data: %+v\n", bd)
+		logger.Info("API Data fetched", "data", bd, "provider", "open-meteo")
+	})
+
 	mux.HandleFunc("GET /meteo", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "OK")


### PR DESCRIPTION
This commit lays the ground work for fetching multi-provider API data by the interface methods that every provider must implement.

It also includes the logic to set log level, which I couldn't pull out as a separate commit. And, an HTTPClient interface signature change.

- Implement Provider interface for open-meteo.com
- Placeholders for meteoblue.com
- Unmarshals the data onto plumber.BaseData struct
- Return HTTPClient for HTTPClient.NewRequest() method so that client methods can be chained as resty natively does.

#5 #2 