### PR TITLE
Inject config as a parameter to providers package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,26 +24,26 @@ func init() {
 	slog.SetDefault(logger)
 }
 
-type config struct {
+type Config struct {
 	Munch          Munch     // Parameters of munch app, excluding external dependencies
 	Mongo          DataStore // Gets picked if DocumentStore is "mongo"
 	DLMRedis       DataStore
 	MeteoProviders []MeteoProvider
 }
 
-func (c *config) GetMunch() Munch {
+func (c *Config) GetMunch() Munch {
 	return c.Munch
 }
 
-func (c *config) GetMongo() DataStore {
+func (c *Config) GetMongo() DataStore {
 	return c.Mongo
 }
 
-func (c *config) GetDLMRedis() DataStore {
+func (c *Config) GetDLMRedis() DataStore {
 	return c.DLMRedis
 }
 
-func (c *config) GetMeteoProviders() []MeteoProvider {
+func (c *Config) GetMeteoProviders() []MeteoProvider {
 	return c.MeteoProviders
 }
 
@@ -72,10 +72,10 @@ type DataStore struct {
 	DBNumber int
 }
 
-var currentConfig *config
+var currentConfig *Config
 var currentConfigErrors error
 
-var defaultConfig = &config{
+var defaultConfig = &Config{
 	Munch: Munch{
 		Server: MunchServer{
 			Hostname: "localhost",
@@ -107,7 +107,7 @@ var defaultConfig = &config{
 // NewDefaultConfig returns a deep copy of the default configuration
 //
 // By doing this, we ensure that newConfig has its own independent copy of the MeteoProviders slice. Therefore, any changes made to newConfig will not affect defaultConfig.
-func NewDefaultConfig() *config {
+func NewDefaultConfig() *Config {
 	newConfig := *defaultConfig
 	newConfig.MeteoProviders = make([]MeteoProvider, len(defaultConfig.MeteoProviders))
 	copy(newConfig.MeteoProviders, defaultConfig.MeteoProviders)
@@ -115,7 +115,7 @@ func NewDefaultConfig() *config {
 }
 
 // Get returns the current configuration that was last loaded, or loads the configuration if it hasn't been loaded yet
-func Get() (*config, error) {
+func Get() (*Config, error) {
 	if currentConfig == nil {
 		currentConfig, currentConfigErrors = Load(nil)
 		// return cfg, err
@@ -126,7 +126,7 @@ func Get() (*config, error) {
 // Load loads the configuration from the file if a preferred config is not provided
 //
 // This is useful when Munch is being used as a package and the user wants to dynamically pass their own configuration
-func Load(c *config) (*config, error) {
+func Load(c *Config) (*Config, error) {
 	currentConfig = NewDefaultConfig() // Assign it to config.currentConfig
 
 	// Use the provided config if it's not nil
@@ -190,7 +190,7 @@ func (e *CriticalErrors) Error() string {
 }
 
 // validateCriticalFields checks for critical parameters in the configuration
-func validateCriticalFields(conf *config, isPanic bool) error {
+func validateCriticalFields(conf *Config, isPanic bool) error {
 	var ve []error // Validation errors
 
 	for _, provider := range conf.MeteoProviders {

--- a/providers/meteoblue.go
+++ b/providers/meteoblue.go
@@ -13,14 +13,14 @@ import (
 
 const meteoBlueProviderName = "meteoblue"
 
-type MeteoBlueProvider struct {
+type MeteoBlue struct {
 	client      rest.HTTPClient
 	config      config.MeteoProvider
 	queryParams map[string]string
 	logLevel    string
 }
 
-func NewMeteoBlueProvider(cfg *config.Config) (*MeteoBlueProvider, error) {
+func newMeteoBlue(cfg *config.Config) (*MeteoBlue, error) {
 	if cfg == nil {
 		return nil, errors.New("configuration cannot be nil")
 	}
@@ -47,7 +47,7 @@ func NewMeteoBlueProvider(cfg *config.Config) (*MeteoBlueProvider, error) {
 		client.EnableTrace()
 	}
 
-	provider := MeteoBlueProvider{
+	provider := MeteoBlue{
 		client:   client,
 		config:   meteoConfig,
 		logLevel: logLevel,
@@ -61,7 +61,7 @@ func NewMeteoBlueProvider(cfg *config.Config) (*MeteoBlueProvider, error) {
 	return &provider, nil
 }
 
-func (p *MeteoBlueProvider) FetchData(coords *plumber.Coordinates) (*plumber.BaseData, error) {
+func (p *MeteoBlue) FetchData(coords *plumber.Coordinates) (*plumber.BaseData, error) {
 	resp, err := p.client.
 		SetQueryParams(map[string]string{
 			"lat": fmt.Sprintf("%f", coords.Latitude),
@@ -106,7 +106,7 @@ func (p *MeteoBlueProvider) FetchData(coords *plumber.Coordinates) (*plumber.Bas
 }
 
 // Set the QueryParams for the request
-func (p *MeteoBlueProvider) SetQueryParams(coords *plumber.Coordinates) {
+func (p *MeteoBlue) SetQueryParams(coords *plumber.Coordinates) {
 	// Setting the queryParams on the provider
 	p.queryParams = map[string]string{
 		"tz":            "GMT",

--- a/providers/open_meteo.go
+++ b/providers/open_meteo.go
@@ -13,15 +13,15 @@ import (
 
 const openMeteoProviderName = "open-meteo"
 
-type OpenMeteoProvider struct {
+type OpenMeteo struct {
 	client      rest.HTTPClient
 	config      config.MeteoProvider
 	queryParams map[string]string
 	logLevel    string
 }
 
-// NewOpenMeteoProvider returns a new instance of OpenMeteoProvider
-func NewOpenMeteoProvider(cfg *config.Config) (*OpenMeteoProvider, error) {
+// newOpenMeteo returns a new instance of OpenMeteoProvider
+func newOpenMeteo(cfg *config.Config) (*OpenMeteo, error) {
 	if cfg == nil {
 		return nil, errors.New("configuration cannot be nil")
 	}
@@ -48,7 +48,7 @@ func NewOpenMeteoProvider(cfg *config.Config) (*OpenMeteoProvider, error) {
 		client.EnableTrace()
 	}
 
-	provider := OpenMeteoProvider{
+	provider := OpenMeteo{
 		client:   client,
 		config:   meteoConfig,
 		logLevel: logLevel,
@@ -62,7 +62,7 @@ func NewOpenMeteoProvider(cfg *config.Config) (*OpenMeteoProvider, error) {
 }
 
 // FetchData fetches API data from open-meteo provider for the given query parameters map
-func (p *OpenMeteoProvider) FetchData(coords *plumber.Coordinates) (*plumber.BaseData, error) {
+func (p *OpenMeteo) FetchData(coords *plumber.Coordinates) (*plumber.BaseData, error) {
 	resp, err := p.client.
 		SetQueryParams(map[string]string{
 			"latitude":  fmt.Sprintf("%f", coords.Latitude),
@@ -95,7 +95,7 @@ func (p *OpenMeteoProvider) FetchData(coords *plumber.Coordinates) (*plumber.Bas
 }
 
 // SetQueryParams forms the query parameters for OpenMeteo API based on given coordinates
-func (p *OpenMeteoProvider) SetQueryParams(coords *plumber.Coordinates) {
+func (p *OpenMeteo) SetQueryParams(coords *plumber.Coordinates) {
 	p.queryParams = map[string]string{
 		"current":        "temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,rain,showers,snowfall,weather_code,cloud_cover,pressure_msl,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m",
 		"hourly":         "temperature_2m,relative_humidity_2m,dew_point_2m,apparent_temperature,precipitation_probability,precipitation,weather_code,pressure_msl,surface_pressure,cloud_cover,cloud_cover_low,cloud_cover_mid,cloud_cover_high,visibility,evapotranspiration,et0_fao_evapotranspiration,vapour_pressure_deficit,wind_speed_10m,wind_speed_80m,wind_speed_120m,wind_speed_180m,wind_direction_10m,wind_direction_80m,wind_direction_120m,wind_direction_180m,wind_gusts_10m,temperature_80m,temperature_120m,temperature_180m,uv_index,uv_index_clear_sky,is_day,sunshine_duration,total_column_integrated_water_vapour,cape,lifted_index,convective_inhibition,freezing_level_height,boundary_layer_height,temperature_1000hPa,temperature_975hPa,temperature_950hPa,temperature_925hPa,temperature_900hPa,temperature_850hPa,temperature_800hPa,temperature_700hPa,temperature_600hPa,temperature_500hPa,temperature_400hPa,relative_humidity_1000hPa,relative_humidity_975hPa,relative_humidity_950hPa,relative_humidity_925hPa,relative_humidity_900hPa,relative_humidity_850hPa,relative_humidity_800hPa,relative_humidity_700hPa,relative_humidity_600hPa,relative_humidity_500hPa,relative_humidity_400hPa,cloud_cover_1000hPa,cloud_cover_975hPa,cloud_cover_950hPa,cloud_cover_925hPa,cloud_cover_900hPa,cloud_cover_850hPa,cloud_cover_800hPa,cloud_cover_700hPa,cloud_cover_600hPa,cloud_cover_500hPa,cloud_cover_400hPa,wind_speed_1000hPa,wind_speed_975hPa,wind_speed_950hPa,wind_speed_925hPa,wind_speed_900hPa,wind_speed_850hPa,wind_speed_800hPa,wind_speed_700hPa,wind_speed_600hPa,wind_speed_500hPa,wind_speed_400hPa,wind_direction_1000hPa,wind_direction_975hPa,wind_direction_950hPa,wind_direction_925hPa,wind_direction_900hPa,wind_direction_850hPa,wind_direction_800hPa,wind_direction_700hPa,wind_direction_600hPa,wind_direction_500hPa,wind_direction_400hPa,geopotential_height_1000hPa,geopotential_height_975hPa,geopotential_height_950hPa,geopotential_height_925hPa,geopotential_height_900hPa,geopotential_height_850hPa,geopotential_height_800hPa,geopotential_height_700hPa,geopotential_height_600hPa,geopotential_height_500hPa,geopotential_height_400hPa",

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -45,17 +45,17 @@ type Provider interface {
 	SetQueryParams(coords *plumber.Coordinates)
 }
 
-// NewProvider returns the appropriate provider based on the name
-func NewProvider(name string, cfg *config.Config) (Provider, error) {
+// New returns the appropriate provider based on the name
+func New(name string, cfg *config.Config) (Provider, error) {
 	switch name {
 	case "open-meteo":
-		p, err := NewOpenMeteoProvider(cfg)
+		p, err := newOpenMeteo(cfg)
 		if err != nil {
 			return nil, err
 		}
 		return p, nil
 	case "meteoblue":
-		p, err := NewMeteoBlueProvider(cfg)
+		p, err := newMeteoBlue(cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -28,6 +28,7 @@ package providers
 import (
 	"fmt"
 
+	"github.com/tinkershack/meteomunch/config"
 	"github.com/tinkershack/meteomunch/logger"
 	"github.com/tinkershack/meteomunch/plumber"
 )
@@ -45,16 +46,16 @@ type Provider interface {
 }
 
 // NewProvider returns the appropriate provider based on the name
-func NewProvider(name string) (Provider, error) {
+func NewProvider(name string, cfg *config.Config) (Provider, error) {
 	switch name {
 	case "open-meteo":
-		p, err := NewOpenMeteoProvider()
+		p, err := NewOpenMeteoProvider(cfg)
 		if err != nil {
 			return nil, err
 		}
 		return p, nil
 	case "meteoblue":
-		p, err := NewMeteoBlueProvider()
+		p, err := NewMeteoBlueProvider(cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,8 @@ func Serve(ctx context.Context, args []string) {
 	})
 
 	mux.HandleFunc("GET /open-meteo", func(w http.ResponseWriter, r *http.Request) {
-		p, err := providers.NewOpenMeteoProvider(cfg)
+		// p, err := providers.NewOpenMeteoProvider(cfg)
+		p, err := providers.New("open-meteo", cfg)
 		if err != nil {
 			logger.Error(e.FAIL, "err", err, "description", "Couldn't create OpenMeteoProvider")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -60,7 +61,8 @@ func Serve(ctx context.Context, args []string) {
 	})
 
 	mux.HandleFunc("GET /meteo", func(w http.ResponseWriter, r *http.Request) {
-		p, err := providers.NewMeteoBlueProvider(cfg)
+		// p, err := providers.NewMeteoBlueProvider(cfg)
+		p, err := providers.New("meteoblue", cfg)
 		if err != nil {
 			logger.Error(e.FAIL, "err", err, "description", "Couldn't create MeteoBlueProvider")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,7 @@ func Serve(ctx context.Context, args []string) {
 	})
 
 	mux.HandleFunc("GET /open-meteo", func(w http.ResponseWriter, r *http.Request) {
-		p, err := providers.NewOpenMeteoProvider()
+		p, err := providers.NewOpenMeteoProvider(cfg)
 		if err != nil {
 			logger.Error(e.FAIL, "err", err, "description", "Couldn't create OpenMeteoProvider")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -60,14 +60,14 @@ func Serve(ctx context.Context, args []string) {
 	})
 
 	mux.HandleFunc("GET /meteo", func(w http.ResponseWriter, r *http.Request) {
-		p, err := providers.NewMeteoBlueProvider()
+		p, err := providers.NewMeteoBlueProvider(cfg)
 		if err != nil {
 			logger.Error(e.FAIL, "err", err, "description", "Couldn't create MeteoBlueProvider")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		// TO-DO : After defining the MB response, write it to the response
-		bd, err := p.FetchData(plumber.NewCoordinates(10.9018379, 76.8998445))
+		bd, err := p.FetchData(plumber.NewCoordinates(11.0056, 76.9661))
 		if err != nil {
 			logger.Error(e.FAIL, "err", err, "description", "Couldn't fetch data from MeteoBlueProvider")
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
- Refactor the NewOpenMeteoProvider() and NewMeteoBlueProvider()
function to accept a *config.Config parameter.
- Update FetchData() method to use the injected configuration.
- Include logLevel field in both the provider struct
- Use NewProvider() to create a new meteo client
- Conform to Go idiomatic naming

Resolves #15 